### PR TITLE
feat: Modify log and trace retention to 3 months

### DIFF
--- a/loki/loki-config.yaml
+++ b/loki/loki-config.yaml
@@ -26,9 +26,15 @@ schema_config:
 
 limits_config:
   allow_structured_metadata: false
+  retention_period: 2160h
 
 ruler:
   alertmanager_url: http://localhost:9093
+
+compactor:
+  working_directory: /tmp/loki/compactor
+  shared_store: filesystem
+  retention_enabled: true
 
 # Docker log scraping must be performed with Promtail (or another log shipper), not in Loki server config.
 # Remove this section and run a Promtail container configured to send logs to Loki.

--- a/tempo/tempo.yaml
+++ b/tempo/tempo.yaml
@@ -16,7 +16,7 @@ ingester:
 
 compactor:
   compaction:
-    block_retention: 24h
+    block_retention: 2160h
 
 storage:
   trace:


### PR DESCRIPTION
This commit modifies the log and trace retention period to 3 months.

- In `loki/loki-config.yaml`, the retention period is set to 2160h (90 days) and the compactor is enabled to enforce the retention policy.
- In `tempo/tempo.yaml`, the block retention is set to 2160h (90 days).